### PR TITLE
Fix ActionButton scaling issues on higher DPI displays

### DIFF
--- a/components/ActionButton.qml
+++ b/components/ActionButton.qml
@@ -48,6 +48,7 @@ Item {
         }
         width: config.PowerIconSize || iconSize
         height: config.PowerIconSize || iconSize
+        sourceSize: Qt.size(width, height)
     }
 
     Label {


### PR DESCRIPTION
Previously, despite the icons being present as SVG files, the icons were being rasterised prior to being scaled to their final size, making them look blurry.

This change simply sets the rasterised version's dimensions on creation, so no scaling needs to take place.

See [this bug](https://bugreports.qt.io/browse/QTBUG-44863) for details.